### PR TITLE
refactor: simplied interface search

### DIFF
--- a/src/factories/ethers-interface.ts
+++ b/src/factories/ethers-interface.ts
@@ -1,63 +1,26 @@
-import { Contract, ContractFactory, ethers } from 'ethers';
+import { ethers } from 'ethers';
 import hre from 'hardhat';
-import { Artifact } from 'hardhat/types';
 import { FakeContractSpec } from '../types';
 
 export async function ethersInterfaceFromSpec(spec: FakeContractSpec): Promise<ethers.utils.Interface> {
-  if (spec instanceof Contract) {
-    return spec.interface;
-  } else if (spec instanceof ContractFactory) {
-    return spec.interface;
-  } else if (spec instanceof ethers.utils.Interface) {
-    return spec;
-  } else if (isInterface(spec)) {
-    return spec as any;
-  } else if (isContractFactory(spec)) {
-    return (spec as any).interface;
-  } else if (isContract(spec)) {
-    return (spec as any).interface;
-  } else if (isArtifact(spec)) {
-    return new ethers.utils.Interface(spec.abi);
-  } else if (typeof spec === 'string') {
+  if (typeof spec === 'string') {
     try {
       return new ethers.utils.Interface(spec);
-    } catch (err) {
+    } catch {
       return (await (hre as any).ethers.getContractFactory(spec)).interface;
     }
-  } else {
-    return new ethers.utils.Interface(spec);
   }
-}
 
-function isInterface(obj: any): boolean {
-  return (
-    obj &&
-    obj.functions !== undefined &&
-    obj.errors !== undefined &&
-    obj.structs !== undefined &&
-    obj.events !== undefined &&
-    Array.isArray(obj.fragments)
-  );
-}
+  let foundInterface: any = spec;
+  if (foundInterface.abi) {
+    foundInterface = foundInterface.abi;
+  } else if (foundInterface.interface) {
+    foundInterface = foundInterface.interface;
+  }
 
-function isContract(obj: any): boolean {
-  return obj && obj.functions !== undefined && obj.estimateGas !== undefined && obj.callStatic !== undefined;
-}
-
-function isContractFactory(obj: any): boolean {
-  return obj && obj.interface !== undefined && obj.deploy !== undefined;
-}
-
-function isArtifact(obj: any): obj is Artifact {
-  return (
-    obj &&
-    typeof obj._format === 'string' &&
-    typeof obj.contractName === 'string' &&
-    typeof obj.sourceName === 'string' &&
-    Array.isArray(obj.abi) &&
-    typeof obj.bytecode === 'string' &&
-    typeof obj.deployedBytecode === 'string' &&
-    obj.linkReferences &&
-    obj.deployedLinkReferences
-  );
+  if (foundInterface instanceof ethers.utils.Interface) {
+    return foundInterface;
+  } else {
+    return new ethers.utils.Interface(foundInterface);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,13 @@
 /* Imports: External */
-import { Fragment, JsonFragment } from '@ethersproject/abi';
+import { Fragment, Interface, JsonFragment } from '@ethersproject/abi';
 import { Provider } from '@ethersproject/abstract-provider';
 import { Signer } from '@ethersproject/abstract-signer';
-import { BaseContract, Contract, ContractFactory, ethers } from 'ethers';
-import { Artifact } from 'hardhat/types';
+import { BaseContract, ContractFactory, ethers } from 'ethers';
 import { EditableStorageLogic } from './logic/editable-storage-logic';
 import { WatchableFunctionLogic } from './logic/watchable-function-logic';
 
-export type FakeContractSpec = Artifact | Contract | ContractFactory | ethers.utils.Interface | string | (JsonFragment | Fragment | string)[];
+type Abi = ReadonlyArray<Fragment | JsonFragment | string>;
+export type FakeContractSpec = { abi?: Abi; interface?: Interface } | Abi | ethers.utils.Interface | string;
 
 export interface FakeContractOptions {
   provider?: Provider;

--- a/test/unit/fake/initialization.spec.ts
+++ b/test/unit/fake/initialization.spec.ts
@@ -4,7 +4,6 @@ import receiverArtifact from 'artifacts/test/contracts/watchable-function-logic/
 import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 
-chai.should();
 chai.use(lopt.matchers);
 
 describe('Fake: Initialization', () => {
@@ -31,9 +30,26 @@ describe('Fake: Initialization', () => {
     expect(fake.receiveEmpty._watchable).not.to.be.undefined;
   });
 
+  it(`should work with the contract interface`, async () => {
+    const factory = (await ethers.getContractFactory('Receiver')) as Receiver__factory;
+    fake = await lopt.fake<Receiver>(factory.interface);
+    expect(fake.receiveEmpty._watchable).not.to.be.undefined;
+  });
+
   it(`should work with the contract`, async () => {
     const factory = (await ethers.getContractFactory('Receiver')) as Receiver__factory;
     fake = await lopt.fake<Receiver>(await factory.deploy());
+    expect(fake.receiveEmpty._watchable).not.to.be.undefined;
+  });
+
+  it(`should work with the contract full path`, async () => {
+    const factory = (await ethers.getContractFactory('test/contracts/watchable-function-logic/Receiver.sol:Receiver')) as Receiver__factory;
+    fake = await lopt.fake<Receiver>(await factory.deploy());
+    expect(fake.receiveEmpty._watchable).not.to.be.undefined;
+  });
+
+  it(`should work with any object thas has an abi inside`, async () => {
+    fake = await lopt.fake<Receiver>({ abi: receiverArtifact.abi });
     expect(fake.receiveEmpty._watchable).not.to.be.undefined;
   });
 });


### PR DESCRIPTION
Added more initialization tests as well.

I wanted to do this because in order to `fake` the `IUniswapV2Pair` I needed to do:
`await lopt.fake(IUniswapV2Pair.abi);`
instead of:
`await lopt.fake(IUniswapV2Pair);`

This happens because the OZ V2 interface doesn't have all the corresponding contract parameters, but we just care about the abi...